### PR TITLE
Update RTClib.cpp

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -1061,7 +1061,8 @@ void RTC_DS3231::writeSqwPinMode(Ds3231SqwPinMode mode) {
 /**************************************************************************/
 float RTC_DS3231::getTemperature()
 {
-  uint8_t msb, lsb;
+  uint8_t lsb;
+  int8_t msb;
   Wire.beginTransmission(DS3231_ADDRESS);
   Wire._I2C_WRITE(DS3231_TEMPERATUREREG);
   Wire.endTransmission();


### PR DESCRIPTION
The current RTC_DS3231::getTemperature function does not handle negative Celsius temperatures correctly.  This correct behavior can be achieved by using a signed 8-bit integer type for the variable "msb" as this allows the sign to be retained for the subsequent float conversion.   Line 1064 was changed to move the "msb" variable to a new line with the int8_t typing. This was tested on an UNO R3 and DS3231 module using a small, frozen blue-ice block with a foam drink cover to achieve negative Celsius temperatures for the DS3231 module.
